### PR TITLE
spec: create a spec file for building stellarsolver RPMs

### DIFF
--- a/spec/stellarsolver.spec
+++ b/spec/stellarsolver.spec
@@ -1,0 +1,56 @@
+%define __cmake_in_source_build %{_vpath_builddir}
+
+Name: stellarsolver
+Version: 1.4.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: The Cross Platform Sextractor and Astrometry.net-Based Internal Astrometric Solver
+
+License: LGPLv3
+
+URL: https://github.com/rlancaste/stellarsolver
+Source0: https://github.com/rlancaste/stellarsolver/archive/master.tar.gz
+
+%global debug_package %{nil}
+%define __find_requires %{nil}
+
+Provides: stellarsolver.so(64-bit)
+Provides: stellarsolver.so
+Provides: stellarsolver.a
+
+BuildRequires: cmake
+BuildRequires: systemd
+BuildRequires: extra-cmake-modules
+
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(wcslib)
+BuildRequires: pkgconfig(Qt5) >= 5.4
+
+
+%description
+An Astrometric Plate Solver for Mac, Linux, and Windows, built on Astrometry.net and SEP (sextractor)
+
+
+%prep -v
+%setup
+
+%build
+%cmake .
+%make_build
+
+
+%install
+#find %buildroot -type f \( -name '*.so' -o -name '*.so.*' \) -exec chmod 755 {} +
+%cmake_install
+%ldconfig_scriptlets
+
+
+%files
+%{_libdir}/*
+%{_includedir}/*
+
+%license LICENSE
+
+%changelog
+* Thu Oct 08 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.4.git
+- introduction of spec file to build RPM packages from git


### PR DESCRIPTION
This is the spec file that allows RPM builds for Fedora and RedHat. Once this is merged, I would request that a webhook is set up in the rlancaste/stellarsolver repo settings.  They type of the webhook is JSON, and the target is:  

https://copr.fedorainfracloud.org/webhooks/github/35866/0ddde295-6a3b-4a2a-b32b-dcb8a0f72858/ 

These are set up in the `settings` section of github, and will allow any changes pushed to trigger a new build of RPM packages for stellarsolver in Copr. These packages are then made available to users directly, as well as pulled in for other builds that require stellarsolver.

Here are the packages created by pointing the build at my branch: https://copr.fedorainfracloud.org/coprs/xsnrg/stellarsolver-bleeding/build/1701395/

Please let me know if you have any questions.  This will allow the RPM builds of kstars to resume, as stellarsolver is now a dependency.

Thanks for all your work on this, I am looking forward to it!

Jim
