### PR TITLE
a quick fix to a library name provided by stellarsolver

### DIFF
--- a/spec/stellarsolver.spec
+++ b/spec/stellarsolver.spec
@@ -14,6 +14,7 @@ Source0: https://github.com/rlancaste/stellarsolver/archive/master.tar.gz
 %define __find_requires %{nil}
 
 Provides: stellarsolver.so(64-bit)
+Provides: libstellarsolver.so.1()(64bit)
 Provides: stellarsolver.so
 Provides: stellarsolver.a
 


### PR DESCRIPTION
I missed one of the crazy lib names... the one kstars wants, of course. This adds it.