### PR TITLE
Use const and return reference whenever possible.

### DIFF
--- a/stellarsolver/parameters.h
+++ b/stellarsolver/parameters.h
@@ -262,7 +262,8 @@ class Parameters
         } ParametersProfile;
 
         QString listName = "Default";       // This is the name of this particular profile of options for StellarSolver
-        QString description = "";           // This is a description of the Profile, what it is intended for, anything that sets it apart
+        QString description =
+            "";           // This is a description of the Profile, what it is intended for, anything that sets it apart
 
         //Sextractor Photometry Parameters
         Shape apertureShape = SHAPE_CIRCLE; // Whether to use the SEP_SUM_ELLIPSE method or the SEP_SUM_CIRCLE method
@@ -316,7 +317,7 @@ class Parameters
         bool resort =
             true;                 // Whether to resort the stars based on magnitude NOTE: This is REQUIRED to be true for the filters above
         bool autoDownsample =       // Whether or not to automatically determine the downsample size based on the image size.
-                true;
+            true;
         int downsample =
             1;                 // Factor to use for downsampling the image before SEP for plate solving.  Can speed it up.  This is not used for Source Extraction
         int search_parity = 2;              // Only check for matches with positive/negative parity (default: try both)

--- a/stellarsolver/stellarsolver.cpp
+++ b/stellarsolver/stellarsolver.cpp
@@ -335,7 +335,7 @@ void StellarSolver::parallelSolve()
         solver->start();
 }
 
-bool StellarSolver::parallelSolversAreRunning()
+bool StellarSolver::parallelSolversAreRunning() const
 {
     for(auto solver : parallelSolvers)
         if(solver->isRunning())
@@ -511,7 +511,7 @@ void StellarSolver::abort()
 }
 
 //This method checks all the solvers and the internal running boolean to determine if anything is running.
-bool StellarSolver::isRunning()
+bool StellarSolver::isRunning() const
 {
     if(parallelSolversAreRunning())
         return true;
@@ -543,7 +543,7 @@ QList<Parameters> StellarSolver::getBuiltInProfiles()
 
     Parameters defaultProfile;
     defaultProfile.listName = "1-Default";
-    defaultProfile.description = "The default profile.  Note that this is not optimized for fast plate solving";
+    defaultProfile.description = "Default profile. Generic and not optimized for any specific purpose.";
     profileList.append(defaultProfile);
 
     Parameters fastSolving;
@@ -553,6 +553,7 @@ QList<Parameters> StellarSolver::getBuiltInProfiles()
     fastSolving.minwidth = 0.1;
     fastSolving.maxwidth = 10;
     fastSolving.keepNum = 50;
+    fastSolving.initialKeep = 500;
     fastSolving.maxEllipse = 1.5;
     createConvFilterFromFWHM(&fastSolving, 4);
     profileList.append(fastSolving);
@@ -563,6 +564,7 @@ QList<Parameters> StellarSolver::getBuiltInProfiles()
     parLargeSolving.minwidth = 10;
     parLargeSolving.maxwidth = 180;
     parLargeSolving.keepNum = 50;
+    parLargeSolving.initialKeep = 500;
     parLargeSolving.maxEllipse = 1.5;
     createConvFilterFromFWHM(&parLargeSolving, 4);
     profileList.append(parLargeSolving);
@@ -573,6 +575,7 @@ QList<Parameters> StellarSolver::getBuiltInProfiles()
     fastSmallSolving.minwidth = 0.1;
     fastSmallSolving.maxwidth = 10;
     fastSmallSolving.keepNum = 50;
+    fastSmallSolving.initialKeep = 500;
     fastSmallSolving.maxEllipse = 1.5;
     createConvFilterFromFWHM(&fastSmallSolving, 4);
     profileList.append(fastSmallSolving);
@@ -592,6 +595,7 @@ QList<Parameters> StellarSolver::getBuiltInProfiles()
     createConvFilterFromFWHM(&smallStars, 1);
     smallStars.r_min = 2;
     smallStars.maxSize = 5;
+    smallStars.initialKeep = 500;
     smallStars.saturationLimit = 80;
     profileList.append(smallStars);
 
@@ -605,6 +609,7 @@ QList<Parameters> StellarSolver::getBuiltInProfiles()
     mid.removeDimmest = 20;
     mid.minSize = 2;
     mid.maxSize = 10;
+    mid.initialKeep = 500;
     mid.saturationLimit = 80;
     profileList.append(mid);
 
@@ -616,6 +621,7 @@ QList<Parameters> StellarSolver::getBuiltInProfiles()
     createConvFilterFromFWHM(&big, 8);
     big.r_min = 20;
     big.minSize = 5;
+    big.initialKeep = 500;
     big.removeDimmest = 50;
     profileList.append(big);
 

--- a/stellarsolver/stellarsolver.h
+++ b/stellarsolver/stellarsolver.h
@@ -164,37 +164,37 @@ class StellarSolver : public QObject
 
 
         //Accessor Method for external classes
-        int getNumStarsFound()
+        int getNumStarsFound() const
         {
             return numStars;
         }
-        QList<FITSImage::Star> getStarList()
+        const QList<FITSImage::Star> &getStarList() const
         {
             return m_ExtractorStars;
         }
-        FITSImage::Background getBackground()
+        const FITSImage::Background &getBackground() const
         {
             return background;
         }
-        QList<FITSImage::Star> getStarListFromSolve()
+        const QList<FITSImage::Star> &getStarListFromSolve() const
         {
             return m_SolverStars;
         }
-        FITSImage::Solution getSolution()
+        const FITSImage::Solution &getSolution() const
         {
             return solution;
         }
 
-        bool sextractionDone()
+        bool sextractionDone() const
         {
             return hasSextracted;
         }
-        bool solvingDone()
+        bool solvingDone() const
         {
             return hasSolved;
         }
 
-        bool failed()
+        bool failed() const
         {
             return hasFailed;
         }
@@ -202,17 +202,17 @@ class StellarSolver : public QObject
         {
             loadWCS = set;
         }
-        bool hasWCSData()
+        bool hasWCSData() const
         {
             return hasWCS;
         };
-        int getNumThreads()
+        int getNumThreads() const
         {
             if(parallelSolvers.size() == 0) return 1;
             else return parallelSolvers.size();
         }
 
-        Parameters getCurrentParameters()
+        const Parameters &getCurrentParameters()
         {
             return params;
         }
@@ -228,7 +228,7 @@ class StellarSolver : public QObject
             m_Subframe = QRect(0, 0, m_Statistics.width, m_Statistics.height);
         };
 
-        bool isRunning();
+        bool isRunning() const;
 
         inline static QString raString(double ra)
         {
@@ -302,7 +302,7 @@ class StellarSolver : public QObject
         QPointer<SextractorSolver> m_SextractorSolver;
         QPointer<SextractorSolver> solverWithWCS;
         int m_ParallelSolversFinishedCount {0};
-        bool parallelSolversAreRunning();
+        bool parallelSolversAreRunning() const;
 
         //The currently set parameters for StellarSolver
         Parameters params;


### PR DESCRIPTION
Use const reference whenever possible to save on unnecessary copy-by-value. Set initial keep for some profile to be more reasonable value than 1,000,000 which can take a lot of time to process on embedded systems.