### PR TITLE
Fix sky background bug, remove partition margin, skip detections overlapping the edge

### DIFF
--- a/stellarsolver/internalsextractorsolver.cpp
+++ b/stellarsolver/internalsextractorsolver.cpp
@@ -331,14 +331,16 @@ int InternalSextractorSolver::runSEPSextractor()
     }
 
     double sumGlobal = 0, sumRmsSq = 0;
-    for (int i = 0; i < backgrounds.size(); ++i)
+    for (const auto& bg : backgrounds)      
     {
-      const auto &bg = backgrounds[i];
-      sumGlobal += bg.global;
-      sumRmsSq += bg.globalrms * bg.globalrms;
+        sumGlobal += bg.global;
+        sumRmsSq += bg.globalrms * bg.globalrms;
     }
-    m_Background.bw = backgrounds[0].bw;
-    m_Background.bh = backgrounds[0].bh;
+    if (!backgrounds.empty())
+    {
+        m_Background.bw = backgrounds[0].bw;
+        m_Background.bh = backgrounds[0].bh;
+    }
     m_Background.num_stars_detected = m_ExtractedStars.size();
     m_Background.global = sumGlobal / backgrounds.size();
     m_Background.globalrms = sqrt( sumRmsSq / backgrounds.size() );

--- a/stellarsolver/internalsextractorsolver.h
+++ b/stellarsolver/internalsextractorsolver.h
@@ -39,6 +39,7 @@ class InternalSextractorSolver: public SextractorSolver
             uint32_t subY;
             uint32_t subW;
             uint32_t subH;
+            FITSImage::Background *background;
         } ImageParams;
 
     protected:
@@ -85,12 +86,5 @@ class InternalSextractorSolver: public SextractorSolver
         bool logMonitorRunning = false;
         FILE *logFile = nullptr;
         uint32_t m_PartitionThreads = {16};
-
-        // Anything below 200 pixels will NOT be partitioned.
-        static const uint32_t PARTITION_SIZE { 200 };
-        // Partition overlap catch any stars that are on the frame EDGE
-        static const uint32_t PARTITION_OVERLAP { 20 };
-        // Partition Margin in pixels
-        static const uint32_t PARTITION_MARGIN { 15 };
 };
 


### PR DESCRIPTION
The returned Background structure (containing sky background values like the brightness and number of stars detected) had a bug in its values, due to the partitioned computation. This is fixed here.

Also, removed the margin (partitions were separated by 15 pixels in an attempt to avoid duplicate star detections).
Instead I used the SEP flag SEP_OBJ_TRUNC which detects when a star overlaps the edge, and those detections are not used.
This reduces the number of stars not detected without causing duplicates.