### PR TITLE
Add wcslib-dev to Linux install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ So please play around with the settings and find out what can work the best.
 ## Linux
 You can follow this set of steps on ubuntu build the program StellarSolver on Linux if you don't want to use the installer above.
 
-	sudo apt -y install git cmake qt5-default libcfitsio-dev libgsl-dev
+	sudo apt -y install git cmake qt5-default libcfitsio-dev libgsl-dev wcslib-dev
 	git clone https://github.com/rlancaste/stellarsolver.git
 	mkdir build
 	cd build


### PR DESCRIPTION
The wcslib-dev package is required for install on linux, and is listed in the linux install script, but is not included in the 'building the program' instructions in the readme file. This fix adds that package to the list for people (like me) who went direct to the build instructions.