### PR TITLE
Protect against malformed subframes that might lead to crashes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,9 @@ cmake_minimum_required(VERSION 3.0)
 # Timestamp build
 string(TIMESTAMP StellarSolver_BUILD_TS UTC)
 
-# StellarSolver Version 1.6
+# StellarSolver Version 1.7
 set (StellarSolver_VERSION_MAJOR 1)
-set (StellarSolver_VERSION_MINOR 6)
+set (StellarSolver_VERSION_MINOR 7)
 
 set (StellarSolver_SOVERSION "${StellarSolver_VERSION_MAJOR}")
 set (StellarSolver_VERSION ${StellarSolver_VERSION_MAJOR}.${StellarSolver_VERSION_MINOR})

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libstellarsolver (1.7) focal; urgency=medium
+
+  * New release.
+
+ -- Jasem Mutlaq <mutlaqja@ikarustech.com>  Sat, 21 Aug 2021 14:00:00 +0300
+
 libstellarsolver (1.5) focal; urgency=medium
 
   * New release.

--- a/stellarsolver/internalsextractorsolver.cpp
+++ b/stellarsolver/internalsextractorsolver.cpp
@@ -233,19 +233,20 @@ int InternalSextractorSolver::runSEPSextractor()
     uint32_t x = 0, y = 0;
     uint32_t w = m_Statistics.width, h = m_Statistics.height;
     uint32_t raw_w = m_Statistics.width, raw_h = m_Statistics.height;
-    if(m_UseSubframe)
+    if(m_UseSubframe && m_SubFrameRect.isValid())
     {
-        x = m_SubFrameRect.x();
-        w = m_SubFrameRect.width();
-        y = m_SubFrameRect.y();
-        h = m_SubFrameRect.height();
+        // JM 2021-08-21 Max sure frame is within acceptable parameters.
+        x = std::max(0, m_SubFrameRect.x());
+        w = std::min(static_cast<int>(raw_w), m_SubFrameRect.width());
+        y = std::max(0, m_SubFrameRect.y());
+        h = std::min(static_cast<int>(raw_h), m_SubFrameRect.height());
 
         raw_w = w;
         raw_h = h;
     }
 
     QList<float *> dataBuffers;
-    QList<QFuture<QList<FITSImage::Star>>> futures;
+    QVector<QFuture<QList<FITSImage::Star>>> futures;
     QList<QPair<uint32_t, uint32_t>> startupOffsets;
     QList<FITSImage::Background> backgrounds;
 
@@ -340,7 +341,7 @@ int InternalSextractorSolver::runSEPSextractor()
     }
 
     double sumGlobal = 0, sumRmsSq = 0;
-    for (const auto &bg : backgrounds)
+    for (const auto &bg : qAsConst(backgrounds))
     {
         sumGlobal += bg.global;
         sumRmsSq += bg.globalrms * bg.globalrms;

--- a/stellarsolver/stellarsolver.cpp
+++ b/stellarsolver/stellarsolver.cpp
@@ -127,8 +127,9 @@ ExternalProgramPaths StellarSolver::getWinCygwinPaths()
 void StellarSolver::extract(bool calculateHFR, QRect frame)
 {
     m_ProcessType = calculateHFR ? EXTRACT_WITH_HFR : EXTRACT;
-    useSubframe = frame.isNull() ? false : true;
-    m_Subframe = frame;
+    useSubframe = !frame.isNull() && frame.isValid();
+    if (useSubframe)
+        m_Subframe = frame;
     start();
     m_SextractorSolver->wait();
 }
@@ -224,7 +225,7 @@ bool StellarSolver::checkParameters()
             emit logOutput("ASTAP no longer supports alternative star extraction methods.  Changing to built-in star extraction.");
         m_SextractorType = EXTRACTOR_BUILTIN;
     }
-    
+
     if(params.multiAlgorithm != NOT_MULTI && m_SolverType == SOLVER_ASTAP && m_ProcessType == SOLVE)
     {
         if(m_SSLogLevel != LOG_OFF)
@@ -459,7 +460,8 @@ void StellarSolver::finishParallelSolve(int success)
             connect(solverWithWCS, &SextractorSolver::logOutput, this, &StellarSolver::logOutput);
             solverWithWCS->start();
         }
-        if(m_SextractorType != EXTRACTOR_BUILTIN) //Note this is just cleaning up the files from the star extraction done prior to the parallel solve.  So for built in, it doesn't even do it, so no files to clean up
+        if(m_SextractorType !=
+                EXTRACTOR_BUILTIN) //Note this is just cleaning up the files from the star extraction done prior to the parallel solve.  So for built in, it doesn't even do it, so no files to clean up
             m_SextractorSolver->cleanupTempFiles();
         m_HasSolved = true;
         emit ready();


### PR DESCRIPTION
As the description says... traced a crash in KStars due to a bad rect. This needs to be fixed in KStars as well, but at least stellarsolver should also run check to ensure it is OK.