### PR TITLE
Use C locale for numbers

### DIFF
--- a/tester/main.cpp
+++ b/tester/main.cpp
@@ -6,6 +6,9 @@ int main(int argc, char *argv[])
 {
 
     QApplication app(argc, argv);
+#if defined(__linux__)
+    setlocale(LC_NUMERIC, "C");
+#endif
     MainWindow *win = new MainWindow();
     app.exec();
     


### PR DESCRIPTION
Tester application doesn't work on locales that use comma as decimal
separator