### PR TITLE
Make it compile on Craft Windows by not including unistd.h

### DIFF
--- a/stellarsolver/astrometry/blind/blind.c
+++ b/stellarsolver/astrometry/blind/blind.c
@@ -14,6 +14,7 @@
 
 #ifndef _WIN32 //# Modified by Robert Lancaster for the StellarSolver Internal Library
 #include <sys/resource.h>
+#include <unistd.h>
 #endif
 #ifndef _MSC_VER //# Modified by Robert Lancaster for the StellarSolver Internal Library
 #include <sys/time.h>
@@ -27,7 +28,6 @@ struct timeval {
 #endif
 
 
-#include <unistd.h>
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>

--- a/stellarsolver/astrometry/blind/blindutils.c
+++ b/stellarsolver/astrometry/blind/blindutils.c
@@ -8,7 +8,11 @@
 #include <libgen.h>
 #endif
 #include <ctype.h>
+
+#ifndef _WIN32
 #include <unistd.h>
+#endif
+
 #include <assert.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/stellarsolver/astrometry/blind/solvedclient.c
+++ b/stellarsolver/astrometry/blind/solvedclient.c
@@ -5,7 +5,6 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <errno.h>
 #include <string.h>
 #include <sys/types.h>
@@ -14,6 +13,7 @@
 #include <winsock2.h>
 #include <string.h>
 #else
+#include <unistd.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>

--- a/stellarsolver/astrometry/blind/solvedfile.c
+++ b/stellarsolver/astrometry/blind/solvedfile.c
@@ -5,7 +5,6 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <errno.h>
 #include <string.h>
 #include <sys/types.h>
@@ -15,6 +14,10 @@
 
 #include "solvedfile.h"
 #include "errors.h"
+
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 //# Modified by Robert Lancaster for the StellarSolver Internal Library
 #if defined(__APPLE__) || defined (_WIN32)

--- a/stellarsolver/astrometry/blind/solver.c
+++ b/stellarsolver/astrometry/blind/solver.c
@@ -13,7 +13,11 @@
 #include <math.h>
 #include <assert.h>
 #include <sys/types.h>
+
+#ifndef _WIN32
 #include <unistd.h>
+#endif
+
 #include <stdarg.h>
 
 #include "os-features.h"

--- a/stellarsolver/astrometry/include/astrometry/qfits_header.h
+++ b/stellarsolver/astrometry/include/astrometry/qfits_header.h
@@ -38,7 +38,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 /*-----------------------------------------------------------------------------
                                    New types
@@ -65,18 +68,18 @@ typedef struct qfits_header qfits_header;
 void qfits_header_debug_dump(const qfits_header*);
 
 int qfits_header_list(const qfits_header* hdr, FILE* out);
-                      
+
 
 
 qfits_header * qfits_header_new(void);
 qfits_header * qfits_header_default(void);
 int qfits_header_n(const qfits_header*);
 void qfits_header_add(qfits_header *, const char *, const char *, const char *,
-        const char *);
-void qfits_header_add_after(qfits_header *, const char *, const char *, 
-        const char *, const char *, const char *);
+                      const char *);
+void qfits_header_add_after(qfits_header *, const char *, const char *,
+                            const char *, const char *, const char *);
 void qfits_header_append(qfits_header *, const char *, const char *,
-        const char *, const char *);
+                         const char *, const char *);
 void qfits_header_del(qfits_header *, const char *);
 int qfits_header_sort(qfits_header **);
 qfits_header * qfits_header_copy(const qfits_header *);
@@ -87,8 +90,8 @@ char* qfits_header_getstr(const qfits_header *, const char *);
 
 int qfits_header_getstr_pretty(const qfits_header* hdr, const char* key, char* pretty, const char* default_val);
 
-int qfits_header_getitem(const qfits_header *, int, char *, char *, char *, 
-        char *); 
+int qfits_header_getitem(const qfits_header *, int, char *, char *, char *,
+                         char *);
 
 /*
   Note, the "key", "val", "comment", args are copied with "strdup", while "line" is

--- a/stellarsolver/astrometry/include/astrometry/qfits_image.h
+++ b/stellarsolver/astrometry/include/astrometry/qfits_image.h
@@ -38,7 +38,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 /*-----------------------------------------------------------------------------
                                    Defines
@@ -70,7 +73,7 @@
                                 ((x) == BPP_16_SIGNED)  ?     2 : \
                                 ((x) == BPP_32_SIGNED)  ?     4 : \
                                 ((x) == BPP_IEEE_FLOAT) ?     4 : \
-                                ((x) == BPP_IEEE_DOUBLE) ?    8 : 0 ) 
+                                ((x) == BPP_IEEE_DOUBLE) ?    8 : 0 )
 
 /*-----------------------------------------------------------------------------
                                    New types
@@ -125,13 +128,14 @@ typedef unsigned char byte;
 
     free(ibuf);
   @endcode
-  
+
   If the provided output file name is "STDOUT" (all capitals), the
   function will dump the pixels to the stdout steam (usually the console,
   could have been re-directed).
  */
 /*----------------------------------------------------------------------------*/
-typedef struct qfitsdumper {
+typedef struct qfitsdumper
+{
 
     /** Name of the file to dump to, "STDOUT" to dump to stdout */
     const char     *    filename;
@@ -147,8 +151,8 @@ typedef struct qfitsdumper {
     /** Pointer to input double pixel buffer */
     const double    *    dbuf;
 
-	/** Pointer to generic pixel buffer. */
-	const void* vbuf;
+    /** Pointer to generic pixel buffer. */
+    const void* vbuf;
 
     /** Requested BITPIX in output FITS file */
     int            out_ptype;

--- a/stellarsolver/astrometry/include/astrometry/qfits_table.h
+++ b/stellarsolver/astrometry/include/astrometry/qfits_table.h
@@ -38,12 +38,15 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 #ifdef _MSC_VER //# Modified by Robert Lancaster for the StellarSolver Internal Library
 #include <sys/types.h>
 #endif
-    
+
 #include "astrometry/qfits_header.h"
 
 /*-----------------------------------------------------------------------------
@@ -64,9 +67,10 @@
 /*----------------------------------------------------------------------------*/
 /**
   @brief    Column data type
- */ 
+ */
 /*----------------------------------------------------------------------------*/
-typedef enum _TFITS_DATA_TYPE_ {
+typedef enum _TFITS_DATA_TYPE_
+{
     TFITS_ASCII_TYPE_A,
     TFITS_ASCII_TYPE_D,
     TFITS_ASCII_TYPE_E,
@@ -92,56 +96,56 @@ typedef enum _TFITS_DATA_TYPE_ {
   @brief    Column object
 
   This structure contains all information needed to read a column in a table.
-  These informations come from the header. 
+  These informations come from the header.
   The qfits_table object contains a list of qfits_col objects.
 
-  This structure has to be created from scratch and filled if one want to 
+  This structure has to be created from scratch and filled if one want to
   generate a FITS table.
  */
 /*----------------------------------------------------------------------------*/
 typedef struct qfits_col
 {
-    /** 
+    /**
       Number of atoms in one field.
      In ASCII tables, it is the number of characters in the field as defined
      in TFORM%d keyword.
-     In BIN tables, it is the number of atoms in each field. For type 'A', 
+     In BIN tables, it is the number of atoms in each field. For type 'A',
      it is the number of characters. A field with two complex object will
      have atom_nb = 4.
     */
     int            atom_nb;
 
     /**
-     Number of decimals in a ASCII field. 
+     Number of decimals in a ASCII field.
      This value is always 0 for BIN tables
     */
     int         atom_dec_nb;
 
-    /** 
+    /**
       Size of one element in bytes. In ASCII tables, atom_size is the size
       of the element once it has been converted in its 'destination' type.
-      For example, if "123" is contained in an ASCII table in a column 
+      For example, if "123" is contained in an ASCII table in a column
       defined as I type, atom_nb=3, atom_size=4.
       In ASCII tables:
        - type 'A' : atom_size = atom_nb = number of chars
        - type 'I', 'F' or 'E' : atom_size = 4
        - type 'D' : atom_size = 8
       In BIN tables :
-       - type 'A', 'L', 'X', 'B': atom_size = 1 
+       - type 'A', 'L', 'X', 'B': atom_size = 1
        - type 'I' : atom_size = 2
        - type 'E', 'J', 'C', 'P' : atom_size = 4
        - type 'D', 'M' : atom_size = 8
-      In ASCII table, there is one element per field. The size in bytes and 
-      in number of characters is atom_nb, and the size in bytes after 
+      In ASCII table, there is one element per field. The size in bytes and
+      in number of characters is atom_nb, and the size in bytes after
       conversion of the field is atom_size.
       In BIN tables, the size in bytes of a field is always atom_nb*atom_size.
      */
-    int            atom_size;    
-    
-    /** 
-      Type of data in the column as specified in TFORM keyword 
-      In ASCII tables : TFITS_ASCII_TYPE_* with *=A, I, F, E or D 
-      In BIN tables : TFITS_BIN_TYPE_* with *=L, X, B, I, J, A, E, D, C, M or P 
+    int            atom_size;
+
+    /**
+      Type of data in the column as specified in TFORM keyword
+      In ASCII tables : TFITS_ASCII_TYPE_* with *=A, I, F, E or D
+      In BIN tables : TFITS_BIN_TYPE_* with *=L, X, B, I, J, A, E, D, C, M or P
     */
     tfits_type    atom_type;
 
@@ -150,28 +154,28 @@ typedef struct qfits_col
 
     /** Unit of the data */
     char        tunit[FITSVALSZ];
-    
+
     /** Null value */
     char        nullval[FITSVALSZ];
 
     /** Display format */
     char        tdisp[FITSVALSZ];
-    
-    /** 
-      zero and scale are used when the quantity in the field does not     
+
+    /**
+      zero and scale are used when the quantity in the field does not
       represent a true physical quantity. Basically, thez should be used
-      when they are present: physical_value = zero + scale * field_value 
+      when they are present: physical_value = zero + scale * field_value
       They are read from TZERO and TSCAL in the header
      */
-    int            zero_present;    
-    float        zero;        
+    int            zero_present;
+    float        zero;
     int            scale_present;
-    float        scale;   
+    float        scale;
 
     /** Offset between the beg. of the table and the beg. of the column.
      NOTE, THIS IS NOT THE OFFSET FROM THE BEGINNING OF THE *ROW*! */
     int            off_beg;
-    
+
     /** Flag to know if the column is readable. An empty col is not readable */
     int            readable;
 } qfits_col;
@@ -182,9 +186,9 @@ typedef struct qfits_col
   @brief    Table object
 
   This structure contains all information needed to read a FITS table.
-  These information come from the header. The object is created by 
+  These information come from the header. The object is created by
   qfits_open().
- 
+
   To read a FITS table, here is a code example:
   @code
   int main(int argc, char* argv[])
@@ -195,12 +199,12 @@ typedef struct qfits_col
 
     // Query the number of extensions
     n_ext = qfits_query_n_ext(argv[1]);
-    
+
     // For each extension
     for (i=0; i<n_ext; i++) {
-        // Read all the infos about the current table 
+        // Read all the infos about the current table
         table = qfits_table_open(argv[1], i+1);
-        // Display the current table 
+        // Display the current table
         dump_extension(table, stdout, '|', 1, 1);
     }
     return;
@@ -214,19 +218,19 @@ typedef struct qfits_table
         Name of the file the table comes from or it is intended to end to
      */
     char            filename[512];
-    /** 
-        Table type. 
+    /**
+        Table type.
         Possible values: QFITS_INVALIDTABLE, QFITS_BINTABLE, QFITS_ASCIITABLE
      */
     int                tab_t;
     /** Width in bytes of the table */
-    int                tab_w;            
+    int                tab_w;
     /** Number of columns */
-    int                nc;            
+    int                nc;
     /** Number of rows */
     int                nr;
     /** Array of qfits_col objects */
-    qfits_col    *    col;            
+    qfits_col    *    col;
 } qfits_table;
 
 /*-----------------------------------------------------------------------------
@@ -238,46 +242,46 @@ qfits_table* qfits_table_copy(const qfits_table* t);
 qfits_header * qfits_table_prim_header_default(void);
 qfits_header * qfits_table_ext_header_default(const qfits_table *);
 qfits_table * qfits_table_new(const char *, int, int, int, int);
-int qfits_col_fill(qfits_col *, int, int, int, tfits_type, const char *, 
-        const char *, const char *, const char *, int, float, int, float, int);
+int qfits_col_fill(qfits_col *, int, int, int, tfits_type, const char *,
+                   const char *, const char *, const char *, int, float, int, float, int);
 
 qfits_table * qfits_table_open2(const qfits_header* hdr, off_t offset_beg, size_t data_size,
-								const char* filename, int xtnum);
+                                const char* filename, int xtnum);
 
 void qfits_table_close(qfits_table *);
 unsigned char * qfits_query_column(const qfits_table *, int, const int *);
 unsigned char * qfits_query_column_seq(const qfits_table *, int, int, int);
-void * qfits_query_column_data(const qfits_table *, int, const int *, 
-        const void *);
-void * qfits_query_column_seq_data(const qfits_table *, int, int, int, 
-        const void *);
+void * qfits_query_column_data(const qfits_table *, int, const int *,
+                               const void *);
+void * qfits_query_column_seq_data(const qfits_table *, int, int, int,
+                                   const void *);
 
 int qfits_query_column_seq_to_array_inds(const qfits_table	    *   th,
-										 int                 colnum,
-										 const int* indices,
-										 int Ninds,
-										 unsigned char*      destination,
-										 int                 dest_stride);
+        int                 colnum,
+        const int* indices,
+        int Ninds,
+        unsigned char*      destination,
+        int                 dest_stride);
 
 int qfits_query_column_seq_to_array(const qfits_table	    *   th,
-									int                 colnum,
-									int                 start_ind,
-									int                 nb_rows,
-									unsigned char*      destination,
-									int                 dest_stride);
+                                    int                 colnum,
+                                    int                 start_ind,
+                                    int                 nb_rows,
+                                    unsigned char*      destination,
+                                    int                 dest_stride);
 
 int qfits_query_column_seq_to_array_no_endian_swap(const qfits_table	    *   th,
-												   int                 colnum,
-												   int                 start_ind,
-												   int                 nb_rows,
-												   unsigned char*      destination,
-												   int                 dest_stride);
+        int                 colnum,
+        int                 start_ind,
+        int                 nb_rows,
+        unsigned char*      destination,
+        int                 dest_stride);
 
-int * qfits_query_column_nulls(const qfits_table *, int, const int *, int *, 
-        int *);
+int * qfits_query_column_nulls(const qfits_table *, int, const int *, int *,
+                               int *);
 
 /**
-  @brief    Compute the table width in bytes from the columns infos 
+  @brief    Compute the table width in bytes from the columns infos
   @param    th      Allocated qfits_table
   @return   the width (-1 in error case)
  */
@@ -286,17 +290,17 @@ int qfits_compute_table_width(const qfits_table * th);
 
 int qfits_table_append_xtension(FILE *, const qfits_table *, const void **);
 int qfits_table_append_xtension_hdr(FILE *, const qfits_table *, const void **,
-        const qfits_header *);
+                                    const qfits_header *);
 char * qfits_table_field_to_string(const qfits_table *, int, int, int);
 
 const qfits_col* qfits_table_get_col(const qfits_table* t, int i);
 
 int qfits_table_interpret_type(
-        const char  *   str,
-        int         *   nb,
-        int         *   dec_nb,
-        tfits_type  *   type,
-        int             table_type);
+    const char  *   str,
+    int         *   nb,
+    int         *   dec_nb,
+    tfits_type  *   type,
+    int             table_type);
 // thread-safe.
 int qfits_is_table_header(const qfits_header* hdr);
 

--- a/stellarsolver/astrometry/qfits-an/anqfits.c
+++ b/stellarsolver/astrometry/qfits-an/anqfits.c
@@ -11,7 +11,11 @@
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+
+#ifndef _WIN32
 #include <unistd.h>
+#endif
+
 #include <assert.h>
 #include <errno.h>
 #include <sys/mman.h>

--- a/stellarsolver/astrometry/qfits-an/qfits_card.c
+++ b/stellarsolver/astrometry/qfits-an/qfits_card.c
@@ -36,7 +36,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 #include "qfits_std.h"
 #include "qfits_card.h"

--- a/stellarsolver/astrometry/qfits-an/qfits_error.c
+++ b/stellarsolver/astrometry/qfits-an/qfits_error.c
@@ -35,7 +35,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifndef _WIN32
 #include <unistd.h>
+#endif
+
 #include <stdarg.h>
 
 #include "qfits_error.h"

--- a/stellarsolver/astrometry/qfits-an/qfits_image.c
+++ b/stellarsolver/astrometry/qfits-an/qfits_image.c
@@ -35,7 +35,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifndef _WIN32
 #include <unistd.h>
+#endif
+
 #include <sys/types.h>
 #include <sys/stat.h>
 

--- a/stellarsolver/astrometry/qfits-an/qfits_memory.c
+++ b/stellarsolver/astrometry/qfits-an/qfits_memory.c
@@ -35,13 +35,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/mman.h>
 #ifndef _WIN32 //# Modified by Robert Lancaster for the StellarSolver Internal Library
 #include <sys/resource.h>
+#include <unistd.h>
 #else
 #include "windows.h"
 #include "io.h"

--- a/stellarsolver/astrometry/qfits-an/qfits_rw.c
+++ b/stellarsolver/astrometry/qfits-an/qfits_rw.c
@@ -34,7 +34,11 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+
+#ifndef _WIN32
 #include <unistd.h>
+#endif
+
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/stellarsolver/astrometry/qfits-an/qfits_table.c
+++ b/stellarsolver/astrometry/qfits-an/qfits_table.c
@@ -35,7 +35,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifndef _WIN32
 #include <unistd.h>
+#endif
+
 #include <ctype.h>
 #include <errno.h>
 #include <assert.h>

--- a/stellarsolver/astrometry/qfits-an/qfits_time.c
+++ b/stellarsolver/astrometry/qfits-an/qfits_time.c
@@ -36,10 +36,10 @@
 #ifndef _WIN32 //# Modified by Robert Lancaster for the StellarSolver Internal Library
 #include <pwd.h>
 #include <sys/time.h>
+#include <unistd.h>
 #else
 #include "tic.h"
 #endif
-#include <unistd.h>
 
 #include "qfits_time.h"
 

--- a/stellarsolver/astrometry/qfits-an/qfits_tools.c
+++ b/stellarsolver/astrometry/qfits-an/qfits_tools.c
@@ -38,12 +38,12 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
 
 #ifdef _WIN32 //# Modified by Robert Lancaster for the StellarSolver Internal Library
 #include <boost/regex.h>
 #else
 #include <regex.h>
+#include <unistd.h>
 #endif
 
 #include "qfits_config.h"

--- a/stellarsolver/astrometry/util/ioutils.c
+++ b/stellarsolver/astrometry/util/ioutils.c
@@ -24,15 +24,14 @@
 #include <stdlib.h>
 #include <signal.h>
 #include <assert.h>
-#include <unistd.h>
 #include <stdarg.h>
-
 
 #include <time.h>
 
 #ifdef _WIN32 //# Modified by Robert Lancaster for the StellarSolver Internal Library
 #include <winsock.h>
 #else
+#include <unistd.h>
 #include <sys/wait.h>
 #include <sys/resource.h>
 #include <sys/select.h>

--- a/stellarsolver/astrometry/util/log.c
+++ b/stellarsolver/astrometry/util/log.c
@@ -7,7 +7,11 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifndef _WIN32
 #include <unistd.h>
+#endif
+
 #include <assert.h>
 
 #include "log.h"

--- a/stellarsolver/astrometry/util/os-features.c
+++ b/stellarsolver/astrometry/util/os-features.c
@@ -5,7 +5,6 @@
 #include <stdlib.h>
 #include <limits.h>
 #include <string.h>
-#include <unistd.h>
 
 #include "os-features.h"
 
@@ -13,6 +12,10 @@
 #define NEED_FDATASYNC 0
 #else
 #define NEED_FDATASYNC 1
+#endif
+
+#ifndef _WIN32
+#include <unistd.h>
 #endif
 
 //# Modified by Robert Lancaster for the StellarSolver Internal Library

--- a/stellarsolver/astrometry/util/permutedsort.c
+++ b/stellarsolver/astrometry/util/permutedsort.c
@@ -5,7 +5,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <stdint.h> //# Modified by Robert Lancaster for the StellarSolver Internal Library
 #include <stdio.h>
 #include <math.h>
@@ -13,6 +12,8 @@
 
 #ifdef _MSC_VER //# Modified by Robert Lancaster for the StellarSolver Internal Library
 #include <sys/types.h>
+#else
+#include <unistd.h>
 #endif
 
 #include "permutedsort.h"

--- a/stellarsolver/astrometry/util/tic.c
+++ b/stellarsolver/astrometry/util/tic.c
@@ -8,12 +8,12 @@
 #ifndef _WIN32 //# Modified by Robert Lancaster for the StellarSolver Internal Library
 #include <sys/resource.h>
 #include <sys/time.h>
+#include <unistd.h>
 #else
 #include <Windows.h>
 #endif
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
 #include <stdint.h>
 
 #include "tic.h"


### PR DESCRIPTION
Looks like with Craft on Windows now it's no longer possible to include unistd.h, which didn't exist on Windows but believe there was a dummy file there so that it compiles.