### PR TITLE
Spec autosetup

### DIFF
--- a/spec/stellarsolver.spec
+++ b/spec/stellarsolver.spec
@@ -33,7 +33,7 @@ An Astrometric Plate Solver for Mac, Linux, and Windows, built on Astrometry.net
 
 
 %prep -v
-%setup
+%autosetup -v
 
 %build
 %cmake .

--- a/spec/stellarsolver.spec
+++ b/spec/stellarsolver.spec
@@ -33,7 +33,7 @@ An Astrometric Plate Solver for Mac, Linux, and Windows, built on Astrometry.net
 
 
 %prep -v
-%autosetup -v
+%autosetup -v -n %{name}-master
 
 %build
 %cmake .


### PR DESCRIPTION
This fixes a build problem for Fedora and switches from using the RPM setup macro to the autosetup macro in the spec file.

Branch build here: https://copr.fedorainfracloud.org/coprs/xsnrg/stellarsolver-bleeding/build/3140971/