### PR TITLE
Detect ASTAP also in /usr/bin

### DIFF
--- a/stellarsolver/externalextractorsolver.cpp
+++ b/stellarsolver/externalextractorsolver.cpp
@@ -51,6 +51,8 @@ ExternalProgramPaths ExternalExtractorSolver::getDefaultExternalPaths(ComputerSy
         (QFile("/bin/astap").exists()) ?
             paths.astapBinaryPath = "/bin/astap" :
             paths.astapBinaryPath = "/opt/astap/astap";
+        if(QFile("/usr/bin/astap").exists())
+            paths.astapBinaryPath = "/usr/bin/astap";
         paths.watneyBinaryPath = "/opt/watney/watney-solve";
         paths.wcsPath = "/usr/bin/wcsinfo";
         break;


### PR DESCRIPTION
On some distro (openSUSE, Fedora, etc), ASTAP is packaged so that it's installed on `/usr/bin`. This commit add support for detecting ASTAP in the aforementioned location.