### PR TITLE
extractPartition cannot be cancelled

### DIFF
--- a/stellarsolver/internalextractorsolver.h
+++ b/stellarsolver/internalextractorsolver.h
@@ -171,7 +171,7 @@ class InternalExtractorSolver: public ExtractorSolver
         /**
          * @brief cancelSEP will cancel a star extraction and wait for it to finish
          */
-        void cancelSEP();
+        void waitSEP();
 
         /**
          * @brief getFloatBuffer gets a float buffer from the image buffer for SEP to perform star extraction


### PR DESCRIPTION
Any function that is executed by QtConcurrent::run cannot be cancelled, so all the cancel code is invalid.

Perhaps we must ensure that imageData passed to extractor MUST remain valid up until the extractor is completed.