### PR TITLE
Protect the futures QList with a mutex

### DIFF
--- a/stellarsolver/internalextractorsolver.cpp
+++ b/stellarsolver/internalextractorsolver.cpp
@@ -20,6 +20,7 @@
 #include "stellarsolver.h"
 #include "sep/extract.h"
 #include "qmath.h"
+#include <QMutexLocker>
 
 //CFitsio Includes
 #include <fitsio.h>
@@ -79,6 +80,7 @@ void InternalExtractorSolver::abort()
 
 void InternalExtractorSolver::waitSEP()
 {
+    QMutexLocker locker(&futuresMutex);
     if (futures.empty())
         return;
 
@@ -259,6 +261,7 @@ void computeMargin(uint32_t x1, uint32_t y1, uint32_t x2, uint32_t y2,
 //I used KStars and the SEP website as a guide for creating these functions
 int InternalExtractorSolver::runSEPExtractor()
 {
+    QMutexLocker locker(&futuresMutex);
     if(convFilter.size() == 0)
     {
         emit logOutput("No convFilter included.");

--- a/stellarsolver/internalextractorsolver.h
+++ b/stellarsolver/internalextractorsolver.h
@@ -9,6 +9,7 @@
 
 #include "extractorsolver.h"
 #include "astrometrylogger.h"
+#include "qmutex.h"
 
 //SEP Includes
 #include "sep/sep.h"
@@ -148,8 +149,9 @@ class InternalExtractorSolver: public ExtractorSolver
         // This is for star extraction, these are the futures for separate threads
         // We need to keep a variable for this avaiable so we can abort the process if needed.
         QVector<QFuture<QList<FITSImage::Star>>> futures;
+        QBasicMutex futuresMutex;
 
-    // InternalExtractorSolver Methods
+        // InternalExtractorSolver Methods
 
         /**
          * @brief prepare_job prepares the job object used by the internal astrometry solver


### PR DESCRIPTION
Protect the QList futures with a mutex.
That is, whenrunSEPExtractor() is runnng, waitSEP() will block until() runSEPExtractor is done -- so the destructor and the abort() method will block until runSEPExtractor is done.