### PR TITLE
Fix online astrometry orientation & HTTPS header for server

### DIFF
--- a/stellarsolver/onlinesolver.cpp
+++ b/stellarsolver/onlinesolver.cpp
@@ -180,8 +180,8 @@ void OnlineSolver::authenticate()
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
 
     // If pure IP, add http to it.
-    if (!astrometryAPIURL.startsWith("http"))
-        astrometryAPIURL = "http://" + astrometryAPIURL;
+    if (!astrometryAPIURL.startsWith("https"))
+        astrometryAPIURL = "https://" + astrometryAPIURL;
 
     QUrl url(astrometryAPIURL);
     url.setPath("/api/login");
@@ -521,7 +521,8 @@ void OnlineSolver::onResult(QNetworkReply *reply)
                 abort();
                 return;
             }
-            orientation *= parity;
+            // For astrometry 0.93 and higher this is no longer needed (sb 7-2023)
+            // orientation *= parity;
             double ra = result["ra"].toDouble(&ok);
             if (ok == false)
             {


### PR DESCRIPTION
It seems I closed yesterday the PR inadvertently. Sorry.Here it goes again.

1. Fix the orientation if using online astrometry.
2. Use HTTPS for astrometry-API-URL. Without secure protocol you do not get the log file.

