### PR TITLE
Fix Linux compilation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ You can follow this set of steps on ubuntu build the program StellarSolver on Li
 	git clone https://github.com/rlancaste/stellarsolver.git
 	mkdir build
 	cd build
-	cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTER=ON ../stellarsolver/
+	cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTER=ON ../
 	make -j $(expr $(nproc) + 2)
 	sudo make install
 


### PR DESCRIPTION
Small issue I found today while trying to compile it under Linux after cding into build/ the right path would be `../` cause `../stellarsolver/` doesn't contain CMakeList