### PR TITLE
Support for Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ option(BUILD_CLI "Build stellarsolver command line interface, instead of just th
 find_package(CFITSIO REQUIRED)
 find_package(GSL REQUIRED)
 find_package(WCSLIB REQUIRED)
-find_package(Qt5 5.4 REQUIRED COMPONENTS Gui Widgets Core Concurrent Network)
+find_package(Qt6 6.2.4 REQUIRED COMPONENTS Gui Widgets Core Concurrent Network)
 
 if(WIN32)
     find_package(Boost 1.45.0 COMPONENTS regex)
@@ -250,10 +250,10 @@ target_link_libraries(stellarsolver
     ${CFITSIO_LIBRARIES}
     ${GSL_LIBRARIES}
     ${WCSLIB_LIBRARIES}
-    Qt5::Core
-    Qt5::Network
-    Qt5::Widgets
-    Qt5::Concurrent
+    Qt6::Core
+    Qt6::Network
+    Qt6::Widgets
+    Qt6::Concurrent
     )
 
 if(WIN32)
@@ -319,11 +319,11 @@ if(BUILD_TESTER OR BUILD_BATCH_SOLVER OR BUILD_DEMOS OR BUILD_TESTS OR BUILD_CLI
         ${CFITSIO_LIBRARIES}
         ${GSL_LIBRARIES}
         ${WCSLIB_LIBRARIES}
-        Qt5::Gui
-        Qt5::Widgets
-        Qt5::Core
-        Qt5::Network
-        Qt5::Concurrent
+        Qt6::Gui
+        Qt6::Widgets
+        Qt6::Core
+        Qt6::Network
+        Qt6::Concurrent
         )
 endif(BUILD_TESTER OR BUILD_BATCH_SOLVER OR BUILD_DEMOS OR BUILD_TESTS OR BUILD_CLI)
 
@@ -338,7 +338,7 @@ set(StellarSolverTester_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/tester/resources.qrc
     )
 
-qt5_wrap_ui(StellarSolverui_SRCS
+qt6_wrap_ui(StellarSolverui_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/tester/mainwindow.ui
     )
 
@@ -365,11 +365,11 @@ target_link_libraries(StellarSolverTester
     ${CFITSIO_LIBRARIES}
     ${GSL_LIBRARIES}
     ${WCSLIB_LIBRARIES}
-    Qt5::Gui
-    Qt5::Widgets
-    Qt5::Core
-    Qt5::Network
-    Qt5::Concurrent
+    Qt6::Gui
+    Qt6::Widgets
+    Qt6::Core
+    Qt6::Network
+    Qt6::Concurrent
     )
 
 if(WIN32)
@@ -405,7 +405,7 @@ if(BUILD_BATCH_SOLVER)
          ${CMAKE_CURRENT_SOURCE_DIR}/stellarbatchsolver/resources.qrc
         )
 
-    qt5_wrap_ui(StellarBatchSolverui_SRCS
+    qt6_wrap_ui(StellarBatchSolverui_SRCS
         ${CMAKE_CURRENT_SOURCE_DIR}/stellarbatchsolver/stellarbatchsolver.ui
         )
 
@@ -431,10 +431,10 @@ if(BUILD_BATCH_SOLVER)
         ${CFITSIO_LIBRARIES}
         ${GSL_LIBRARIES}
         ${WCSLIB_LIBRARIES}
-        Qt5::Widgets
-        Qt5::Core
-        Qt5::Network
-        Qt5::Concurrent
+        Qt6::Widgets
+        Qt6::Core
+        Qt6::Network
+        Qt6::Concurrent
         )
 
     if(WIN32)
@@ -471,10 +471,10 @@ if(BUILD_DEMOS)
         ${CFITSIO_LIBRARIES}
         ${GSL_LIBRARIES}
         ${WCSLIB_LIBRARIES}
-        Qt5::Widgets
-        Qt5::Core
-        Qt5::Network
-        Qt5::Concurrent
+        Qt6::Widgets
+        Qt6::Core
+        Qt6::Network
+        Qt6::Concurrent
         )
 
     add_executable(DemoStarExtract ${CMAKE_CURRENT_SOURCE_DIR}/demos/demostarextract.cpp)
@@ -518,8 +518,8 @@ if(BUILD_CLI)
         ${CFITSIO_LIBRARIES}
         ${GSL_LIBRARIES}
         ${WCSLIB_LIBRARIES}
-        Qt5::Core
-        Qt5::Concurrent
+        Qt6::Core
+        Qt6::Concurrent
         )
 
     add_executable(CommandLineInterface ${CMAKE_CURRENT_SOURCE_DIR}/cli/main.cpp)
@@ -554,10 +554,10 @@ if(BUILD_TESTS)
         ${CFITSIO_LIBRARIES}
         ${GSL_LIBRARIES}
         ${WCSLIB_LIBRARIES}
-        Qt5::Widgets
-        Qt5::Core
-        Qt5::Network
-        Qt5::Concurrent
+        Qt6::Widgets
+        Qt6::Core
+        Qt6::Network
+        Qt6::Concurrent
         )
 
     add_executable(TestTwoStellarSolvers ${CMAKE_CURRENT_SOURCE_DIR}/tests/testtwostellarsolvers.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ configure_file(
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
 
 if(APPLE)
     set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15)
@@ -92,9 +93,6 @@ endif(WIN32)
 # We aren't using netpbm in this program, so set this to 0 no matter what
 file(APPEND "${config_FN}" "#define HAVE_NETPBM 0")
 
-# Option to choose between Qt5 and Qt6
-option(USE_QT5 "Use Qt5" On)
-
 option(BUILD_TESTER "Build stellarsolver tester program, instead of just the library" Off)
 option(BUILD_BATCH_SOLVER "Build stellarsolver batch solver program, instead of just the library" Off)
 option(BUILD_DEMOS "Build stellarsolver basic demonstration programs, instead of just the library" Off)
@@ -105,25 +103,10 @@ find_package(CFITSIO REQUIRED)
 find_package(GSL REQUIRED)
 find_package(WCSLIB REQUIRED)
 
-if(USE_QT5)
-    find_package(Qt5 5.4 REQUIRED COMPONENTS Gui Widgets Core Concurrent Network)
-    set(Qt_LIBRARIES
-        ${Qt5Gui_LIBRARIES}
-        ${Qt5Widgets_LIBRARIES}
-        ${Qt5Core_LIBRARIES}
-        ${Qt5Concurrent_LIBRARIES}
-        ${Qt5Network_LIBRARIES}
-    )
-else()
-    find_package(Qt6 6.2.4 REQUIRED COMPONENTS Gui Widgets Core Concurrent Network)
-    set(Qt_LIBRARIES
-        ${Qt6Gui_LIBRARIES}
-        ${Qt6Widgets_LIBRARIES}
-        ${Qt6Core_LIBRARIES}
-        ${Qt6Concurrent_LIBRARIES}
-        ${Qt6Network_LIBRARIES}
-    )
-endif(USE_QT5)
+find_package(Qt6 REQUIRED COMPONENTS Gui Widgets Core Concurrent Network)
+if (NOT Qt6_FOUND)
+    find_package(Qt5 5.15 REQUIRED COMPONENTS Gui Widgets Core Concurrent Network)
+endif()
 
 if(WIN32)
     find_package(Boost 1.45.0 COMPONENTS regex)
@@ -272,7 +255,10 @@ target_link_libraries(stellarsolver
     ${CFITSIO_LIBRARIES}
     ${GSL_LIBRARIES}
     ${WCSLIB_LIBRARIES}
-    ${Qt_LIBRARIES}
+    Qt::Core
+    Qt::Network
+    Qt::Widgets
+    Qt::Concurrent
     )
 
 if(WIN32)
@@ -338,7 +324,11 @@ if(BUILD_TESTER OR BUILD_BATCH_SOLVER OR BUILD_DEMOS OR BUILD_TESTS OR BUILD_CLI
         ${CFITSIO_LIBRARIES}
         ${GSL_LIBRARIES}
         ${WCSLIB_LIBRARIES}
-        ${Qt_LIBRARIES}
+        Qt::Gui
+        Qt::Widgets
+        Qt::Core
+        Qt::Network
+        Qt::Concurrent
         )
 endif(BUILD_TESTER OR BUILD_BATCH_SOLVER OR BUILD_DEMOS OR BUILD_TESTS OR BUILD_CLI)
 
@@ -352,16 +342,6 @@ set(StellarSolverTester_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/tester/mainwindow.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tester/resources.qrc
     )
-
-if(USE_QT5)
-    qt5_wrap_ui(StellarSolverui_SRCS
-    ${CMAKE_CURRENT_SOURCE_DIR}/tester/mainwindow.ui
-    )
-else()
-    qt6_wrap_ui(StellarSolverui_SRCS
-    ${CMAKE_CURRENT_SOURCE_DIR}/tester/mainwindow.ui
-    )
-endif(USE_QT5)
 
 if(APPLE)
 set(MACOSX_BUNDLE_ICON_FILE StellarSolverIcon.icns)
@@ -386,7 +366,11 @@ target_link_libraries(StellarSolverTester
     ${CFITSIO_LIBRARIES}
     ${GSL_LIBRARIES}
     ${WCSLIB_LIBRARIES}
-    ${Qt_LIBRARIES}
+    Qt::Gui
+    Qt::Widgets
+    Qt::Core
+    Qt::Network
+    Qt::Concurrent
     )
 
 if(WIN32)
@@ -422,15 +406,9 @@ if(BUILD_BATCH_SOLVER)
          ${CMAKE_CURRENT_SOURCE_DIR}/stellarbatchsolver/resources.qrc
         )
 
-    if(USE_QT5)
-        qt5_wrap_ui(StellarBatchSolverui_SRCS
-            ${CMAKE_CURRENT_SOURCE_DIR}/stellarbatchsolver/stellarbatchsolver.ui
-            )
-    else()
-        qt6_wrap_ui(StellarBatchSolverui_SRCS
-            ${CMAKE_CURRENT_SOURCE_DIR}/stellarbatchsolver/stellarbatchsolver.ui
-            )
-    endif(USE_QT5)
+    qt_wrap_ui(StellarBatchSolverui_SRCS
+        ${CMAKE_CURRENT_SOURCE_DIR}/stellarbatchsolver/stellarbatchsolver.ui
+        )
 
     if(APPLE)
     set(MACOSX_BUNDLE_ICON_FILE StellarBatchSolverIcon.icns)
@@ -454,7 +432,10 @@ if(BUILD_BATCH_SOLVER)
         ${CFITSIO_LIBRARIES}
         ${GSL_LIBRARIES}
         ${WCSLIB_LIBRARIES}
-        ${Qt_LIBRARIES}
+        Qt::Widgets
+        Qt::Core
+        Qt::Network
+        Qt::Concurrent
         )
 
     if(WIN32)
@@ -491,7 +472,10 @@ if(BUILD_DEMOS)
         ${CFITSIO_LIBRARIES}
         ${GSL_LIBRARIES}
         ${WCSLIB_LIBRARIES}
-        ${Qt_LIBRARIES}
+        Qt::Widgets
+        Qt::Core
+        Qt::Network
+        Qt::Concurrent
         )
 
     add_executable(DemoStarExtract ${CMAKE_CURRENT_SOURCE_DIR}/demos/demostarextract.cpp)
@@ -535,7 +519,8 @@ if(BUILD_CLI)
         ${CFITSIO_LIBRARIES}
         ${GSL_LIBRARIES}
         ${WCSLIB_LIBRARIES}
-        ${Qt_LIBRARIES}
+        Qt::Core
+        Qt::Concurrent
         )
 
     add_executable(CommandLineInterface ${CMAKE_CURRENT_SOURCE_DIR}/cli/main.cpp)
@@ -570,8 +555,11 @@ if(BUILD_TESTS)
         ${CFITSIO_LIBRARIES}
         ${GSL_LIBRARIES}
         ${WCSLIB_LIBRARIES}
-        ${Qt_LIBRARIES}
-         )
+        Qt::Widgets
+        Qt::Core
+        Qt::Network
+        Qt::Concurrent
+    )
 
     add_executable(TestTwoStellarSolvers ${CMAKE_CURRENT_SOURCE_DIR}/tests/testtwostellarsolvers.cpp)
     target_link_libraries(TestTwoStellarSolvers StellarSolverTestsLib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,9 @@ endif(WIN32)
 # We aren't using netpbm in this program, so set this to 0 no matter what
 file(APPEND "${config_FN}" "#define HAVE_NETPBM 0")
 
+# Option to choose between Qt5 and Qt6
+option(USE_QT5 "Use Qt5" On)
+
 option(BUILD_TESTER "Build stellarsolver tester program, instead of just the library" Off)
 option(BUILD_BATCH_SOLVER "Build stellarsolver batch solver program, instead of just the library" Off)
 option(BUILD_DEMOS "Build stellarsolver basic demonstration programs, instead of just the library" Off)
@@ -101,7 +104,26 @@ option(BUILD_CLI "Build stellarsolver command line interface, instead of just th
 find_package(CFITSIO REQUIRED)
 find_package(GSL REQUIRED)
 find_package(WCSLIB REQUIRED)
-find_package(Qt6 6.2.4 REQUIRED COMPONENTS Gui Widgets Core Concurrent Network)
+
+if(USE_QT5)
+    find_package(Qt5 5.4 REQUIRED COMPONENTS Gui Widgets Core Concurrent Network)
+    set(Qt_LIBRARIES
+        ${Qt5Gui_LIBRARIES}
+        ${Qt5Widgets_LIBRARIES}
+        ${Qt5Core_LIBRARIES}
+        ${Qt5Concurrent_LIBRARIES}
+        ${Qt5Network_LIBRARIES}
+    )
+else()
+    find_package(Qt6 6.2.4 REQUIRED COMPONENTS Gui Widgets Core Concurrent Network)
+    set(Qt_LIBRARIES
+        ${Qt6Gui_LIBRARIES}
+        ${Qt6Widgets_LIBRARIES}
+        ${Qt6Core_LIBRARIES}
+        ${Qt6Concurrent_LIBRARIES}
+        ${Qt6Network_LIBRARIES}
+    )
+endif(USE_QT5)
 
 if(WIN32)
     find_package(Boost 1.45.0 COMPONENTS regex)
@@ -250,10 +272,7 @@ target_link_libraries(stellarsolver
     ${CFITSIO_LIBRARIES}
     ${GSL_LIBRARIES}
     ${WCSLIB_LIBRARIES}
-    Qt6::Core
-    Qt6::Network
-    Qt6::Widgets
-    Qt6::Concurrent
+    ${Qt_LIBRARIES}
     )
 
 if(WIN32)
@@ -319,11 +338,7 @@ if(BUILD_TESTER OR BUILD_BATCH_SOLVER OR BUILD_DEMOS OR BUILD_TESTS OR BUILD_CLI
         ${CFITSIO_LIBRARIES}
         ${GSL_LIBRARIES}
         ${WCSLIB_LIBRARIES}
-        Qt6::Gui
-        Qt6::Widgets
-        Qt6::Core
-        Qt6::Network
-        Qt6::Concurrent
+        ${Qt_LIBRARIES}
         )
 endif(BUILD_TESTER OR BUILD_BATCH_SOLVER OR BUILD_DEMOS OR BUILD_TESTS OR BUILD_CLI)
 
@@ -338,9 +353,15 @@ set(StellarSolverTester_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/tester/resources.qrc
     )
 
-qt6_wrap_ui(StellarSolverui_SRCS
+if(USE_QT5)
+    qt5_wrap_ui(StellarSolverui_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/tester/mainwindow.ui
     )
+else()
+    qt6_wrap_ui(StellarSolverui_SRCS
+    ${CMAKE_CURRENT_SOURCE_DIR}/tester/mainwindow.ui
+    )
+endif(USE_QT5)
 
 if(APPLE)
 set(MACOSX_BUNDLE_ICON_FILE StellarSolverIcon.icns)
@@ -365,11 +386,7 @@ target_link_libraries(StellarSolverTester
     ${CFITSIO_LIBRARIES}
     ${GSL_LIBRARIES}
     ${WCSLIB_LIBRARIES}
-    Qt6::Gui
-    Qt6::Widgets
-    Qt6::Core
-    Qt6::Network
-    Qt6::Concurrent
+    ${Qt_LIBRARIES}
     )
 
 if(WIN32)
@@ -405,9 +422,15 @@ if(BUILD_BATCH_SOLVER)
          ${CMAKE_CURRENT_SOURCE_DIR}/stellarbatchsolver/resources.qrc
         )
 
-    qt6_wrap_ui(StellarBatchSolverui_SRCS
-        ${CMAKE_CURRENT_SOURCE_DIR}/stellarbatchsolver/stellarbatchsolver.ui
-        )
+    if(USE_QT5)
+        qt5_wrap_ui(StellarBatchSolverui_SRCS
+            ${CMAKE_CURRENT_SOURCE_DIR}/stellarbatchsolver/stellarbatchsolver.ui
+            )
+    else()
+        qt6_wrap_ui(StellarBatchSolverui_SRCS
+            ${CMAKE_CURRENT_SOURCE_DIR}/stellarbatchsolver/stellarbatchsolver.ui
+            )
+    endif(USE_QT5)
 
     if(APPLE)
     set(MACOSX_BUNDLE_ICON_FILE StellarBatchSolverIcon.icns)
@@ -431,10 +454,7 @@ if(BUILD_BATCH_SOLVER)
         ${CFITSIO_LIBRARIES}
         ${GSL_LIBRARIES}
         ${WCSLIB_LIBRARIES}
-        Qt6::Widgets
-        Qt6::Core
-        Qt6::Network
-        Qt6::Concurrent
+        ${Qt_LIBRARIES}
         )
 
     if(WIN32)
@@ -471,10 +491,7 @@ if(BUILD_DEMOS)
         ${CFITSIO_LIBRARIES}
         ${GSL_LIBRARIES}
         ${WCSLIB_LIBRARIES}
-        Qt6::Widgets
-        Qt6::Core
-        Qt6::Network
-        Qt6::Concurrent
+        ${Qt_LIBRARIES}
         )
 
     add_executable(DemoStarExtract ${CMAKE_CURRENT_SOURCE_DIR}/demos/demostarextract.cpp)
@@ -518,8 +535,7 @@ if(BUILD_CLI)
         ${CFITSIO_LIBRARIES}
         ${GSL_LIBRARIES}
         ${WCSLIB_LIBRARIES}
-        Qt6::Core
-        Qt6::Concurrent
+        ${Qt_LIBRARIES}
         )
 
     add_executable(CommandLineInterface ${CMAKE_CURRENT_SOURCE_DIR}/cli/main.cpp)
@@ -554,11 +570,8 @@ if(BUILD_TESTS)
         ${CFITSIO_LIBRARIES}
         ${GSL_LIBRARIES}
         ${WCSLIB_LIBRARIES}
-        Qt6::Widgets
-        Qt6::Core
-        Qt6::Network
-        Qt6::Concurrent
-        )
+        ${Qt_LIBRARIES}
+         )
 
     add_executable(TestTwoStellarSolvers ${CMAKE_CURRENT_SOURCE_DIR}/tests/testtwostellarsolvers.cpp)
     target_link_libraries(TestTwoStellarSolvers StellarSolverTestsLib)

--- a/linux-scripts/installStellarSolverLibrary.sh
+++ b/linux-scripts/installStellarSolverLibrary.sh
@@ -7,7 +7,7 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../
 if [ -f /usr/lib/fedora-release ]; then
   sudo dnf -y install git cmake qt5 cfitsio-devel gsl-devel wcslib-devel
 else
-  sudo apt -y install git cmake qt5-default libcfitsio-dev libgsl-dev wcslib-dev
+  sudo apt -y install git cmake qt6-base-dev libcfitsio-dev libgsl-dev wcslib-dev
 fi
 
 #This makes and installs the library

--- a/linux-scripts/installStellarSolverLibrary.sh
+++ b/linux-scripts/installStellarSolverLibrary.sh
@@ -7,7 +7,10 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../
 if [ -f /usr/lib/fedora-release ]; then
   sudo dnf -y install git cmake qt5 cfitsio-devel gsl-devel wcslib-devel
 else
-  sudo apt -y install git cmake qt6-base-dev libcfitsio-dev libgsl-dev wcslib-dev
+    # Qt5 dependencies
+    sudo apt -y install git cmake qt5-default libcfitsio-dev libgsl-dev wcslib-dev
+    # Qt6 dependencies
+    # sudo apt -y install git cmake qt6-base-dev libcfitsio-dev libgsl-dev wcslib-dev
 fi
 
 #This makes and installs the library

--- a/stellarsolver/externalextractorsolver.cpp
+++ b/stellarsolver/externalextractorsolver.cpp
@@ -1312,7 +1312,8 @@ bool ExternalExtractorSolver::getSolutionInformation()
     //This is a quick way to find out what keys are available
     // emit logOutput(wcsinfo_stdout);
 
-    QStringList wcskeys = wcsinfo_stdout.split(QRegExp("[\n]"));
+    static QRegularExpression separatorPattern("[\n]");
+    QStringList wcskeys = wcsinfo_stdout.split(separatorPattern);
 
     QStringList key_value;
 

--- a/stellarsolver/internalextractorsolver.cpp
+++ b/stellarsolver/internalextractorsolver.cpp
@@ -404,7 +404,7 @@ int InternalExtractorSolver::runSEPExtractor()
                                           m_ActiveParameters.initialKeep / m_PartitionThreads,
                                           &backgrounds[backgrounds.size() - 1]
                                          };
-                futures.append(QtConcurrent::run(this, &InternalExtractorSolver::extractPartition, parameters));
+                futures.append(QtConcurrent::run(&InternalExtractorSolver::extractPartition, this, parameters));
             }
         }
     }
@@ -430,7 +430,7 @@ int InternalExtractorSolver::runSEPExtractor()
         backgrounds.append(tempBackground);
 
         ImageParams parameters = {data, subWidth, subHeight, 0, 0, subWidth, subHeight, static_cast<uint32_t>(m_ActiveParameters.initialKeep), &backgrounds[backgrounds.size() - 1]};
-        futures.append(QtConcurrent::run(this, &InternalExtractorSolver::extractPartition, parameters));
+        futures.append(QtConcurrent::run(&InternalExtractorSolver::extractPartition, this, parameters));
     }
 
     for (auto &oneFuture : futures)

--- a/stellarsolver/internalextractorsolver.cpp
+++ b/stellarsolver/internalextractorsolver.cpp
@@ -404,7 +404,11 @@ int InternalExtractorSolver::runSEPExtractor()
                                           m_ActiveParameters.initialKeep / m_PartitionThreads,
                                           &backgrounds[backgrounds.size() - 1]
                                          };
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+                futures.append(QtConcurrent::run(this, &InternalExtractorSolver::extractPartition, parameters));
+#else
                 futures.append(QtConcurrent::run(&InternalExtractorSolver::extractPartition, this, parameters));
+#endif
             }
         }
     }
@@ -430,7 +434,11 @@ int InternalExtractorSolver::runSEPExtractor()
         backgrounds.append(tempBackground);
 
         ImageParams parameters = {data, subWidth, subHeight, 0, 0, subWidth, subHeight, static_cast<uint32_t>(m_ActiveParameters.initialKeep), &backgrounds[backgrounds.size() - 1]};
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+        futures.append(QtConcurrent::run(this, &InternalExtractorSolver::extractPartition, parameters));
+#else
         futures.append(QtConcurrent::run(&InternalExtractorSolver::extractPartition, this, parameters));
+#endif
     }
 
     for (auto &oneFuture : futures)


### PR DESCRIPTION
This change adds the option to build stellar solver with the Qt6 framework.

Installation of dependencies for Ubuntu:
```shell
sudo snap install kf6-core22
sudo apt-get -y install qt6-base-dev libgl1-mesa-dev libqt6svg6-dev libqt6websockets6-dev qt6-declarative-dev qtkeychain-qt6-dev libqt6datavisualization6-dev
```

### Compiling with Qt6
```shell
mkdir build && cd build
cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_QT5=Off ..
```

Qt5 is still the default. If the option `-DUSE_QT5=Off` is omitted or used as `-DUSE_QT5=On`, cmake is configured for using Qt5.

### Open topics
- Adaption of the build scripts, which still only support Qt5
