### PR TITLE
Support for both Qt5 and Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,9 +101,14 @@ option(BUILD_CLI "Build stellarsolver command line interface, instead of just th
 find_package(CFITSIO REQUIRED)
 find_package(GSL REQUIRED)
 find_package(WCSLIB REQUIRED)
-find_package(Qt6 REQUIRED COMPONENTS Gui Widgets Core Concurrent Network)
-if (NOT Qt6_FOUND)
+
+# Option to choose between Qt5 and Qt6
+option(USE_QT5 "Use Qt5" Off)
+
+if(USE_QT5)
     find_package(Qt5 5.15 REQUIRED COMPONENTS Gui Widgets Core Concurrent Network)
+else()
+    find_package(Qt6 REQUIRED COMPONENTS Gui Widgets Core Concurrent Network)
 endif()
 
 if(WIN32)


### PR DESCRIPTION
The CMakeLists.txt obtains a flag whether Qt5 or Qt6 is used. This makes it possible using it in both a Qt5 and Qt6 environment.