### PR TITLE
Implement saving fits with solution data via cli

### DIFF
--- a/ssolverutils/fileio.cpp
+++ b/ssolverutils/fileio.cpp
@@ -712,7 +712,7 @@ bool fileio::parseHeader()
 }
 
 //This was copied and pasted and modified from ImageToFITS and injectWCS in fitsdata in KStars
-bool fileio::saveAsFITS(QString fileName, FITSImage::Statistic &imageStats, uint8_t *imageBuffer, FITSImage::Solution solution, QList<Record> &records, bool hasSolution)
+bool fileio::saveAsFITS(QString fileName, FITSImage::Statistic &imageStats, uint8_t *imageBuffer, FITSImage::Solution solution, const QList<Record> &records, bool hasSolution)
 {
     int status = 0;
     fitsfile * new_fptr;

--- a/ssolverutils/fileio.h
+++ b/ssolverutils/fileio.h
@@ -43,7 +43,7 @@ public:
     bool loadImageBufferOnly(QString fileName);
     bool loadFits(QString fileName);
     bool parseHeader();
-    bool saveAsFITS(QString fileName, FITSImage::Statistic &imageStats, uint8_t *m_ImageBuffer, FITSImage::Solution solution, QList<Record> &records, bool hasSolution);
+    bool saveAsFITS(QString fileName, FITSImage::Statistic &imageStats, uint8_t *m_ImageBuffer, FITSImage::Solution solution, const QList<Record> &records, bool hasSolution);
     bool loadOtherFormat(QString fileName);
     bool checkDebayer();
     bool debayer();


### PR DESCRIPTION
Adds a new feature for the new `cli` program, which I find very handy. Thanks btw. for this `cli`! :slightly_smiling_face:

No checks for existing file are done here, thus the warning is given in the help message. If this behavior is not wanted, I can try and built in a check-and-ask-the-user function.